### PR TITLE
NO_JIRA security hardening: CSP, tabnapping, robots, analytics

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,3 +1,3 @@
 Contact: mailto:jashaba@live.com
-Expires: 2025-12-31T23:59:59.000Z
+Expires: 2027-01-01T00:00:00.000Z
 Preferred-Language: en 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,17 +6,17 @@
 			</a>
 		</li>
 		<li class="nav-item">
-			<a class="nav-link" href="https://x.com/{{site.x_username }}" target="_blank">
+			<a class="nav-link" href="https://x.com/{{site.x_username }}" target="_blank" rel="noopener noreferrer">
 				<i class="bi bi-twitter-x"></i>
 			</a>
 		</li>
 		<li class="nav-item">
-			<a class="nav-link" href="https://github.com/{{ site.github_username }}" target="_blank">
+			<a class="nav-link" href="https://github.com/{{ site.github_username }}" target="_blank" rel="noopener noreferrer">
 				<i class="bi bi-github"></i>
 			</a>
 		</li>
 		<li class="nav-item">
-			<a class="nav-link" href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank">
+			<a class="nav-link" href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank" rel="noopener noreferrer">
 				<i class="bi bi-linkedin"></i>
 			</a>
 		</li>

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,11 +1,4 @@
-<!-- Google Analytics 4 -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
-<script>
-  if(!(window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1")) {
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', '{{ site.google_analytics }}');
-  }
-</script>
-  
+<!-- Google Analytics 4 — initialized by assets/js/analytics.js -->
+<meta name="ga-measurement-id" content="{{ site.google_analytics }}">
+<script src="{{ '/assets/js/analytics.js' | relative_url }}" defer></script>
+

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,8 +15,7 @@
 	<!-- Favicon -->
 	<link rel="icon" type="image/x-icon" href="{{ '/favicon.ico' | relative_url }}">
     <!-- Security headers -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://plausible.io; connect-src 'self' https://www.google-analytics.com https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data:;">
-    <meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://plausible.io; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com; base-uri 'self'; form-action 'self';">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
     {%- seo -%}

--- a/_includes/resume/header.html
+++ b/_includes/resume/header.html
@@ -3,7 +3,7 @@
 	<div class="d-flex flex-column flex-md-row gap-3 text-muted">
 		<span>Austin, TX</span>
 		<span><a href="mailto:{{ site.email }}">{{ site.email }}</a></span>
-		<span><a href="https://github.com/{{ site.github_username }}" target="_blank">GitHub</a></span>
-		<span><a href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank">LinkedIn</a></span>
+		<span><a href="https://github.com/{{ site.github_username }}" target="_blank" rel="noopener noreferrer">GitHub</a></span>
+		<span><a href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank" rel="noopener noreferrer">LinkedIn</a></span>
 	</div>
 </section>

--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,27 @@
+(function () {
+  // Respect Do Not Track preference
+  if (
+    window.doNotTrack === "1" ||
+    navigator.doNotTrack === "1" ||
+    navigator.doNotTrack === "yes" ||
+    navigator.msDoNotTrack === "1"
+  ) {
+    return;
+  }
+
+  var meta = document.querySelector('meta[name="ga-measurement-id"]');
+  if (!meta || !meta.content) return;
+
+  var gaId = meta.content;
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  window.gtag = gtag;
+  gtag("js", new Date());
+  gtag("config", gaId);
+
+  var script = document.createElement("script");
+  script.async = true;
+  script.src = "https://www.googletagmanager.com/gtag/js?id=" + gaId;
+  document.head.appendChild(script);
+})();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,3 +24,16 @@ function handleHashChange() {
 
 window.addEventListener("DOMContentLoaded", handleHashChange);
 window.addEventListener("hashchange", handleHashChange);
+
+// Profile image load animation (replaces inline onload handler)
+window.addEventListener("DOMContentLoaded", function () {
+    var profileImg = document.querySelector('img[data-role="profile"]');
+    if (!profileImg) return;
+    if (profileImg.complete) {
+        profileImg.classList.add("loaded");
+    } else {
+        profileImg.addEventListener("load", function () {
+            profileImg.classList.add("loaded");
+        });
+    }
+});

--- a/index.html
+++ b/index.html
@@ -33,13 +33,13 @@ layout: default
 <div class="container text-center py-5">
 	<div class="row justify-content-center">
 		<div class="col-md-8 col-lg-6">
-			<img 
+			<img
 				src="/assets/images/real-ash.png"
-				class="img-fluid rounded-circle mb-4" 
-				alt="John Ashabahebwa - Software Engineer from Uganda now based in Austin, Texas" 
+				class="img-fluid rounded-circle mb-4"
+				alt="John Ashabahebwa - Software Engineer from Uganda now based in Austin, Texas"
 				loading="lazy"
 				style="max-width: 250px"
-				onload="this.classList.add('loaded')"
+				data-role="profile"
 			/>
 			<div class="greeting-text">
 				<h1 class="mb-3 fw-medium">Hi there 👋</h1>

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,3 @@
 User-agent: *
 Allow: /
 Sitemap: https://ashabahebwa.com/sitemap.xml
-Disallow: /private/
-Disallow: /admin/ 


### PR DESCRIPTION
## Description

Security hardening pass based on a passive security audit of ashabahebwa.com.

- **CSP strengthened** — removed `unsafe-inline` and `unsafe-eval` from `script-src`; added `base-uri 'self'` and `form-action 'self'`; dropped the `X-Frame-Options` meta tag (browsers ignore it in meta position)
- **GA inline script eliminated** — moved Google Analytics initialization to `assets/js/analytics.js`, loaded via `<script src defer>`. The HTML now emits only a meta tag with the measurement ID. No inline JS needed
- **Inline event handler removed** — `onload="this.classList.add('loaded')"` on the profile image moved to `main.js`
- **Tabnapping fixed** — added `rel="noopener noreferrer"` to all `target="_blank"` links in `footer.html` and `resume/header.html`
- **robots.txt cleaned up** — removed `Disallow: /private/` and `Disallow: /admin/` entries; these paths don't exist on the static site and advertising them hints at potential attack surfaces
- **security.txt expiry updated** — was set to 2025-12-31 (expired); updated to 2027-01-01

## Related Jira Tickets

NO_JIRA

## Screenshots (if any)

No visual changes.